### PR TITLE
Correct emitting, when rdmStarted is set to true

### DIFF
--- a/lib/rtags.js
+++ b/lib/rtags.js
@@ -174,6 +174,7 @@ module.exports.RcExecutor = class RcExecutor extends EventEmitter {
           reject(stdout);
         }
         this.rdmStarted = true;
+        this.emit('rdmStarted');
         resolve(stdout);
       }.bind(this, this.messageId);
       try {


### PR DESCRIPTION
Linting wasn't enabled when rdm is manually started and rc_exec "discovers" it has already been started