### PR TITLE
fixed linter was crashing when error list is empty

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -58,6 +58,7 @@ class RtagsLinter {
   }
 
   setErrorsForFile(filePath, errors) {
+    errors = errors || [];
     this.current_linter_messages[filePath] = [];
     for (let error of errors) {
       if (error.$.severity === "skipped" || error.$.severity === "none" ) {


### PR DESCRIPTION
when the linter is updated and a file does not contain errors anymore, it crashes and display is not updated. This leads to the last error in a file never being removed.